### PR TITLE
Add publisher module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repo has the following folder structure:
 To deploy the agentless integration for a specific log/metrics aggregation to Honeycomb.io:
 
 * [postgresql](modules/postgresql/README.md)
+* [publisher](modules/publisher/README.md)
 
 ## How do I contribute to this Module?
 

--- a/modules/publisher/README.md
+++ b/modules/publisher/README.md
@@ -1,0 +1,64 @@
+# Honeycomb Publisher for Lambda
+
+The Honeycomb Publisher for Lambda receives and publishes Honeycomb events on behalf of other Honeycomb-instrumented Lambda functions. It allows events to be sent asynchronously, rather 
+than blocking the upstream function. The source function is modified so that its instrumentation goes to STDOUT. Lambda writes this output to a Cloudwatch Log Group, and the publisher subscribes to one or more Cloudwatch Log Groups and sends the instrumentation on to Honeycomb.
+
+A sample event looks like this. Fields are stored in the `data` map, the event timestamp comes from the `time` field, and the target dataset is specified in `dataset`. If `dataset` is missing, events go to a fallback dataset (see below).
+
+```json
+{
+    "data": {
+        "key": "8825.samplerate.int32c",
+        "object_size": 537310,
+        "open_elapsed_ms": 111,
+        "reached_eof": true,
+        "stream_total_ms": 689,
+        "sum_bytes_read": 537310
+    },
+    "time": "2019-08-20T18:53:08.443956295Z",
+    "dataset": "target-dataset"
+}
+```
+
+[Honeycomb Beelines](https://docs.honeycomb.io/getting-data-in/beelines/) and SDKs have built-in support for output to STDOUT. Consult the documentation for your language to learn how to enable it.
+
+## How to use this Module
+
+Example:
+
+```hcl
+module "honeycomb_publisher" {
+  source               = "terra-farm/honeycomb/aws/modules/publisher"
+  version              = "0.0.3"
+  project              = "your-application-project-name"
+  environment          = "production"
+  # defines which log groups to read from.
+  subscription_filters = ["/path/to/my/log/group1", "/path/to/my/log/group/2"]
+  # used as a fallback if no dataset is included in the event data
+  dataset              = "your-dataset-name-on-honeycomb"
+  lambda_version       = "1.6.0"
+  honeycomb_write_key  = "CiphertextBlob-of-your-KMS-encrypted-honeycomb-write-key"
+  kms_key_id           = "kms-key-id-used-to-encrypt-the-write-key"
+}
+```
+
+## How do I contribute to this Module?
+
+Contributions are very welcome! Check out the [Contribution Guidelines](https://github.com/terra-farm/terraform-aws-honeycomb/tree/master/CONTRIBUTING.md) for instructions.
+
+
+## How is this Module versioned?
+
+This Module follows the principles of [Semantic Versioning](http://semver.org/). You can find each new release, 
+along with the changelog, in the [Releases Page](https://github.com/terra-farm/terraform-aws-honeycomb/releases). 
+
+During initial development, the major version will be 0 (e.g., `0.x.y`), which indicates the code does not yet have a 
+stable API. Once we hit `1.0.0`, we will make every effort to maintain a backwards compatible API and use the MAJOR, 
+MINOR, and PATCH versions on each release to indicate any incompatibilities. 
+
+
+## License
+
+This code is released under the Apache 2.0 License. 
+Please see [LICENSE](https://github.com/terra-farm/terraform-aws-honeycomb/tree/master/LICENSE) for more 
+details.

--- a/modules/publisher/main.tf
+++ b/modules/publisher/main.tf
@@ -1,0 +1,43 @@
+module "permissions" {
+  source           = "../iam"
+  project          = "${var.project}"
+  environment      = "${var.environment}"
+  integration_type = "publisher"
+  kms_key_id       = "${var.kms_key_id}"
+}
+
+data "aws_region" "current" {}
+
+resource "aws_lambda_function" "honeycomb_publisher" {
+  s3_bucket     = "honeycomb-integrations-${data.aws_region.current.name}"
+  s3_key        = "agentless-integrations-for-aws/${var.lambda_version}/ingest-handlers.zip"
+  function_name = "honeycomb-publisher-${var.project}-${var.environment}-logs"
+  role          = "${module.permissions.honeycomb_logs_role_arn}"
+  handler       = "publisher"
+  runtime       = "go1.x"
+  memory_size   = "128"
+
+  environment {
+    variables = {
+      API_HOST            = "${var.honeycomb_api_host}"
+      HONEYCOMB_WRITE_KEY = "${var.honeycomb_write_key}"
+      KMS_KEY_ID          = "${var.kms_key_id}"
+      DATASET             = "${var.dataset}"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "subscription_filters" {
+  for_each        = toset(var.subscription_filters)
+  name            = "honeycomb-publisher-${each.key}"
+  log_group_name  = each.key
+  filter_pattern  = ""
+  destination_arn = "${aws_lambda_function.honeycomb_publisher.arn}"
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.honeycomb_publisher.arn}"
+  principal     = "logs.amazonaws.com"
+}

--- a/modules/publisher/variables.tf
+++ b/modules/publisher/variables.tf
@@ -1,0 +1,33 @@
+variable "project" {
+  description = "Name of the project."
+}
+
+variable "environment" {
+  description = "Name of the environment."
+}
+
+variable "lambda_version" {
+  description = "Version of the Honeycomb.io agentless Lambda function(s) to deploy. See [here](https://github.com/honeycombio/agentless-integrations-for-aws/releases) for the available versions."
+  default     = "LATEST"
+}
+
+variable "dataset" {
+  description = "Catch-all dataset used if upstream events did not include a dataset"
+}
+
+variable "honeycomb_write_key" {
+  description = "Encrypted version of the Honeycomb write key."
+}
+
+variable "kms_key_id" {
+  description = "ID of the AWS KMS key used to encrypt the Honeycomb write key."
+}
+
+variable "subscription_filters" {
+  type        = list(string)
+  description = "List of AWS Cloudwatch Log Groups to subscribe to. This will create one subscription filter per group."
+}
+
+variable "honeycomb_api_host" {
+  default = "https://api.honeycomb.io"
+}


### PR DESCRIPTION
This implements the publisher integration (https://github.com/honeycombio/agentless-integrations-for-aws) used to asynchronously forward events from Lambda to Honeycomb. We use it internally, but it's a bit of tech debt for us because we use the CFN template to deploy it while we use terraform everywhere else, so this would be nice to have.

First time writing one of these modules for publishing. I copied this to our internal modules directory and ran tf plan - it did everything I was expecting, but curious if I missed anything.