### PR TITLE
docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This repo has the following folder structure:
 
 To deploy the agentless integration for a specific log/metrics aggregation to Honeycomb.io:
 
-* [postgresql](modules/postgresql/README.md)
-* [publisher](modules/publisher/README.md)
+* [postgresql](https://github.com/terra-farm/terraform-aws-honeycomb/blob/master/modules/postgresql/README.md)
+* [publisher](https://github.com/terra-farm/terraform-aws-honeycomb/blob/master/modules/publisher/README.md)
 
 ## How do I contribute to this Module?
 

--- a/modules/publisher/README.md
+++ b/modules/publisher/README.md
@@ -28,7 +28,7 @@ Example:
 
 ```hcl
 module "honeycomb_publisher" {
-  source               = "terra-farm/honeycomb/aws/modules/publisher"
+  source               = "terra-farm/honeycomb/aws//modules/publisher"
   version              = "0.0.3"
   project              = "your-application-project-name"
   environment          = "production"


### PR DESCRIPTION
- For some reason, tf doesn't accept `terra-farm/honeycomb/aws/modules/publisher` as a valid, versioned module source, and complains about it being a non-Registry URL. Need an extra `/` i.e. `terra-farm/honeycomb/aws//modules/publisher`
- The relative module README.md links don't work when the module docs are deployed to the registry page here: https://registry.terraform.io/modules/terra-farm/honeycomb/aws. Update these to include the absolute path in github.